### PR TITLE
use relative path if startdir unchanged

### DIFF
--- a/plugin/grep.vim
+++ b/plugin/grep.vim
@@ -560,6 +560,9 @@ function! s:RunGrepRecursive(cmd_name, grep_cmd, action, ...)
     if startdir == ""
         return
     endif
+    if startdir == cwd
+    	let startdir = "."
+    endif
     echo "\r"
 
     if filepattern == ""


### PR DESCRIPTION
When using Rgrep, if user has not changed the prompted directory to
start the search from, then we can just use "." instead of its absolute
path. It makes the grep output the relative paths in result, the output
becomes shorter and more readable.
