### PR TITLE
Don't shellescape parts of search patterns

### DIFF
--- a/autoload/grep.vim
+++ b/autoload/grep.vim
@@ -570,7 +570,7 @@ function! s:parseArgs(cmd_name, args)
 	    let cmdopt = cmdopt . ' ' . one_arg
 	elseif pattern == ''
 	    " Only one search pattern can be specified
-	    let pattern = shellescape(one_arg)
+	    let pattern = one_arg
 	else
 	    " More than one file patterns can be specified
 	    if filepattern != ''
@@ -693,7 +693,6 @@ function! grep#runGrepRecursive(cmd_name, grep_cmd, action, ...)
 	if pattern == ''
 	    return
 	endif
-	let pattern = shellescape(pattern)
 	echo "\r"
     endif
 
@@ -866,7 +865,6 @@ function! grep#runGrep(cmd_name, grep_cmd, action, ...)
 	if pattern == ''
 	    return
 	endif
-	let pattern = shellescape(pattern)
 	echo "\r"
     endif
 


### PR DESCRIPTION
Fixes https://github.com/yegappan/grep/issues/9

The (incomplete) patterns were shellescape()'d. Even if the full pattern were parsed by s:parseArgs(), it isn't necessary since the user is typing in an argument to a command in the shell in the first place.

Note there is a separate issue in the original code in how s:parseArgs() incorrectly assumes that the first non-option argument is the entire search pattern. Vim's `<f-args>` doesn't handle quotes like shell quoting, unfortunately, making this assumption in s:parseArgs() incorrect. I went ahead and opened #11 to track this separate issue.