### PR TITLE
fix: cursor changed when action=set

### DIFF
--- a/autoload/grep.vim
+++ b/autoload/grep.vim
@@ -438,11 +438,10 @@ function! s:runGrepCmdAsync(cmd, pattern, action)
     endif
 
     let title = '[Search results for ' . a:pattern . ']'
-    if a:action == 'add'
-	caddexpr title . "\n"
-    else
-	cexpr title . "\n"
+    if a:action == 'set'
+    call setqflist([], 'r')
     endif
+    caddexpr title . "\n"
     "caddexpr 'Search cmd: "' . a:cmd . '"'
     call setqflist([], 'a', {'title' : title})
     " Save the quickfix list id, so that the grep output can be added to


### PR DESCRIPTION
 grep#runGrep with action=set will change the cursor position of original buffer, because of 'cexpr'. Use setqlist to avoid this.